### PR TITLE
Use url-dispatcher instead of ual.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ pkg_check_modules (SERVICE_DEPS REQUIRED
                    libaccounts-glib>=1.18
                    messaging-menu>=12.10
                    uuid>=2.25
-                   ubuntu-app-launch-3)
+                   )
 include_directories (SYSTEM ${SERVICE_DEPS_INCLUDE_DIRS})
 
 ##

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -24,8 +24,7 @@
 #include <messaging-menu/messaging-menu-app.h>
 #include <messaging-menu/messaging-menu-message.h>
 
-#include <libubuntu-app-launch-3/ubuntu-app-launch/appid.h>
-#include <libubuntu-app-launch-3/ubuntu-app-launch/registry.h>
+#include <url-dispatcher.h>
 
 #include <uuid/uuid.h>
 
@@ -461,13 +460,16 @@ private:
 
     static std::string calendar_app_id()
     {
-        auto registry = std::make_shared<ubuntu::app_launch::Registry>();
-        auto app_id = ubuntu::app_launch::AppID::discover(registry, "ubuntu-calendar-app");
-        if (!app_id.empty())
+        auto urls = g_strsplit("calendar://", "\n", 0);
+        auto appids = url_dispatch_url_appid(const_cast<const gchar**>(urls));
+        g_strfreev(urls);
+        std::string result;
+        if (appids != nullptr) {
             // Due the use of old API by messaging_menu we need append a extra ".desktop" to the app_id.
-            return std::string(app_id) + ".desktop";
-        else
-            return std::string();
+            result = std::string(appids[0]) + ".desktop";
+            g_strfreev(appids);
+        }
+        return result;
     }
 
     static std::string calendar_app_icon()


### PR DESCRIPTION
As ubuntu-app-launch has different API versions across release branches,
and url-dispatcher is more stable and provides sufficient API to perform
the task of discovering the appid for calendar, use it instead. This also
makes the notification work better if using deb builds instead of clicks,
and should save a little CPU time in the process.