### PR TITLE
Snooze alarm after timeout

### DIFF
--- a/src/snap.cpp
+++ b/src/snap.cpp
@@ -172,7 +172,7 @@ public:
         b.set_closed_callback([appointment, alarm, on_response, sound, awake, haptic]
                               (const std::string& action){
             Snap::Response response;
-            if (action == ACTION_SNOOZE)
+            if ((action == ACTION_SNOOZE) || (appointment.is_ubuntu_alarm() && action.empty()))
                 response = Snap::Response::Snooze;
             else if (action == ACTION_SHOW_APP)
                 response = Snap::Response::ShowApp;


### PR DESCRIPTION
This PR changes the default behavior for an alarm timeout from "no action" to "snooze".

Tested on BQ E5, the alarm snoozes correctly after it is left to timeout.