### PR TITLE
Start snooze from the current minute

### DIFF
--- a/src/planner-snooze.cpp
+++ b/src/planner-snooze.cpp
@@ -59,7 +59,9 @@ public:
         appt.alarms.push_back(alarm);
 
         // reschedule the alarm to go off N minutes from now
-        const auto offset = std::chrono::minutes(m_settings->snooze_duration.get());
+        // also take into count every whole minute since the alarm went off
+        const auto offset_to_now = std::chrono::duration_cast<std::chrono::minutes>(std::chrono::microseconds(DateTime::NowLocal() - appt.begin));
+        const auto offset = offset_to_now + std::chrono::minutes(m_settings->snooze_duration.get());
         appt.begin += offset;
         appt.end += offset;
         appt.alarms[0].time += offset;


### PR DESCRIPTION
SnoozePlanner just added the snooze duration to the start of the alarm. If the Snooze button was pressed 10 minutes after the alarm started and the snooze duration is 5 minutes then the alarm is planned into the past. This PR adds every whole minute passed between the start of the alarm and the Snooze action.

Tested on BQ E5. The snooze duration was working as expected.