### PR TITLE
Add option to show/hide alarms

### DIFF
--- a/data/com.canonical.indicator.datetime.gschema.xml.in.in
+++ b/data/com.canonical.indicator.datetime.gschema.xml.in.in
@@ -94,6 +94,13 @@
 			  Shows events from Evolution in indicator-datetime's menu.
 			</_description>
 		</key>
+        <key name="show-alarms" type="b">
+			<default>true</default>
+			<_summary>Show alarms in the indicator</_summary>
+			<_description>
+			  Shows alarms in the events list in indicator-datetime's menu.
+			</_description>
+		</key>
 		<key name="show-auto-detected-location" type="b">
 			<default>false</default>
 			<_summary>Show the auto-detected location in the indicator</_summary>

--- a/include/datetime/menu.h
+++ b/include/datetime/menu.h
@@ -51,7 +51,8 @@ public:
     static std::vector<Appointment> get_display_appointments(
         const std::vector<Appointment>&,
         const DateTime& start,
-        unsigned int max_items=5);
+        unsigned int max_items=5,
+        const bool include_alarms=true);
 
 protected:
     Menu (Profile profile_in, const std::string& name_in);

--- a/include/datetime/settings-live.h
+++ b/include/datetime/settings-live.h
@@ -53,6 +53,7 @@ private:
     void update_show_day();
     void update_show_detected_locations();
     void update_show_events();
+    void update_show_alarms();
     void update_show_locations();
     void update_show_seconds();
     void update_show_week_numbers();

--- a/include/datetime/settings-shared.h
+++ b/include/datetime/settings-shared.h
@@ -41,6 +41,7 @@ TimeFormatMode;
 #define SETTINGS_SHOW_CALENDAR_S        "show-calendar"
 #define SETTINGS_SHOW_WEEK_NUMBERS_S    "show-week-numbers"
 #define SETTINGS_SHOW_EVENTS_S          "show-events"
+#define SETTINGS_SHOW_ALARMS_S          "show-alarms"
 #define SETTINGS_SHOW_LOCATIONS_S       "show-locations"
 #define SETTINGS_SHOW_DETECTED_S        "show-auto-detected-location"
 #define SETTINGS_LOCATIONS_S            "locations"

--- a/include/datetime/settings.h
+++ b/include/datetime/settings.h
@@ -50,6 +50,7 @@ public:
     core::Property<bool> show_day;
     core::Property<bool> show_detected_location;
     core::Property<bool> show_events;
+    core::Property<bool> show_alarms;
     core::Property<bool> show_locations;
     core::Property<bool> show_seconds;
     core::Property<bool> show_week_numbers;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -139,7 +139,10 @@ GVariant* create_calendar_state(const std::shared_ptr<State>& state)
 {
     gboolean days[32] = { 0 };
     for (const auto& appt : state->calendar_month->appointments().get())
-        days[appt.begin.day_of_month()] = true;
+        if (!appt.is_ubuntu_alarm() || (appt.is_ubuntu_alarm() && state->settings->show_alarms.get()))
+        {
+            days[appt.begin.day_of_month()] = true;
+        }
 
     GVariantBuilder day_builder;
     g_variant_builder_init(&day_builder, G_VARIANT_TYPE("ai"));

--- a/src/settings-live.cpp
+++ b/src/settings-live.cpp
@@ -53,6 +53,7 @@ LiveSettings::LiveSettings():
     update_show_day();
     update_show_detected_locations();
     update_show_events();
+    update_show_alarms();
     update_show_locations();
     update_show_seconds();
     update_show_week_numbers();
@@ -109,6 +110,10 @@ LiveSettings::LiveSettings():
 
     show_events.changed().connect([this](bool value){
         g_settings_set_boolean(m_settings, SETTINGS_SHOW_EVENTS_S, value);
+    });
+
+    show_alarms.changed().connect([this](bool value){
+        g_settings_set_boolean(m_settings, SETTINGS_SHOW_ALARMS_S, value);
     });
 
     show_locations.changed().connect([this](bool value){
@@ -236,6 +241,12 @@ void LiveSettings::update_show_events()
 {
     const auto val = g_settings_get_boolean(m_settings, SETTINGS_SHOW_EVENTS_S);
     show_events.set(val);
+}
+
+void LiveSettings::update_show_alarms()
+{
+    const auto val = g_settings_get_boolean(m_settings, SETTINGS_SHOW_ALARMS_S);
+    show_alarms.set(val);
 }
 
 void LiveSettings::update_show_locations()
@@ -416,6 +427,8 @@ void LiveSettings::update_key_ccid(const std::string& key)
         update_show_week_numbers();
     else if (key == SETTINGS_SHOW_EVENTS_S)
         update_show_events();
+    else if (key == SETTINGS_SHOW_ALARMS_S)
+        update_show_alarms();
     else if (key == SETTINGS_SHOW_LOCATIONS_S)
         update_show_locations();
     else if (key == SETTINGS_SHOW_DETECTED_S)

--- a/tests/test-menus.cpp
+++ b/tests/test-menus.cpp
@@ -272,6 +272,19 @@ private:
         for (int i=0, n=appointments.size(); i<n; i++)
             InspectAppointmentMenuItem(section, first_appt_index+i, appointments[i]);
 
+        // there shouldn't be any alarms when "show alarms" is false
+        bool has_ubuntu_alarms = false;
+
+        m_state->settings->show_alarms.set(false);
+        
+        for (int i=0, n=appointments.size(); i<n; i++)
+            if((has_ubuntu_alarms = appointments[i].is_ubuntu_alarm()))
+                break;            
+
+        EXPECT_FALSE(has_ubuntu_alarms);
+
+        m_state->settings->show_alarms.set(true);
+
         //g_clear_object(&section);
         //g_clear_object(&submenu);
     }


### PR DESCRIPTION
The new setting can show or hide alarms in the events list and calendar dots.